### PR TITLE
Fix: Arguments in fslroi.

### DIFF
--- a/utils/calculate_dvars.sh
+++ b/utils/calculate_dvars.sh
@@ -36,7 +36,7 @@ echo -n "."
 # Compute temporal difference time series
 nVol=$(fslnvols "$FUNC")
 fslroi "$FUNC" $Tmp-FUNC0 0 $((nVol-1))
-fslroi "$FUNC" $Tmp-FUNC1 1 $nVol
+fslroi "$FUNC" $Tmp-FUNC1 1 $((nVol-1))
 echo -n "."
 # Compute DVARS, no standization
 fslmaths $Tmp-FUNC0 -sub $Tmp-FUNC1                $Tmp-Diff -odt float


### PR DESCRIPTION
In FSL6, third argument of fslroi is the size in t-dimension, not the last point, so it has to stay the same for both calls. 

I do not understand why this worked before, perhaps the inferface was different in earlier FSL versions?